### PR TITLE
Fix BigInt Serialization in Attestation Decoding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 WORKDIR /app
 ENV NODE_ENV=production
 

--- a/utils.ts
+++ b/utils.ts
@@ -424,7 +424,10 @@ export async function getFormattedAttestationFromLog(
     }
 
     const schemaEncoder = new SchemaEncoder(schema.schema);
-    decodedDataJson = JSON.stringify(schemaEncoder.decodeData(data));
+    decodedDataJson = JSON.stringify(schemaEncoder.decodeData(data), (_, value) =>
+      typeof value === "bigint" ? value.toString() : value
+    );
+    
   } catch (error) {
     console.log("Error decoding data 53432", error);
   }
@@ -876,7 +879,10 @@ export async function updateDbFromEthTransaction(txId: string) {
     }
 
     const schemaEncoder = new SchemaEncoder(schema.schema);
-    decodedDataJson = JSON.stringify(schemaEncoder.decodeData(pkg.sig.message.data));
+    decodedDataJson = JSON.stringify(schemaEncoder.decodeData(pkg.sig.message.data), (_, value) =>
+      typeof value === "bigint" ? value.toString() : value
+    );
+
   } catch (error) {
     throw new Error("Error decoding offchain attestation data: " + error);
   }


### PR DESCRIPTION
This PR includes two main changes:
- BigInt Serialization for Decoded Attestation Data: Updated the attestation decoding logic to safely serialize [BigInt] values when converting decoded data to JSON, preventing runtime errors and ensuring compatibility.
- Node.js Version Upgrade in Docker: The Docker base image was updated to use Node.js 20 or higher, ensuring compatibility with dependencies that require newer Node.js versions.